### PR TITLE
SF Changes

### DIFF
--- a/Dockerfile-timezone
+++ b/Dockerfile-timezone
@@ -1,5 +1,5 @@
 FROM mhart/alpine-node:10.7
-RUN apk update && apk upgrade && apk add --no-cache tzdata file imagemagick
+RUN apk update && apk upgrade && apk add --no-cache tzdata file imagemagick curl
 ENV TZ America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etclocaltime && echo $TZ > /etc/timezone
 WORKDIR /code/

--- a/Dockerfile-timezone
+++ b/Dockerfile-timezone
@@ -1,5 +1,5 @@
 FROM mhart/alpine-node:10.7
-RUN apk add --no-cache tzdata
+RUN apk update && apk upgrade && apk add --no-cache tzdata file imagemagick
 ENV TZ America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etclocaltime && echo $TZ > /etc/timezone
 WORKDIR /code/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 FROM mhart/alpine-node:10.7.0
-RUN apk update && apk upgrade && apk add git && npm i -g nodemon > /dev/null
+RUN apk update && apk upgrade && apk add git file imagemagick && npm i -g nodemon > /dev/null
 WORKDIR /code/
 COPY package*.json ./
 RUN npm i > /dev/null

--- a/handlers/sf/gg.js
+++ b/handlers/sf/gg.js
@@ -1,0 +1,7 @@
+module.exports = (bot) => {
+    bot.hears(['gg','golden gate'], ({reply}) => {
+        const cc = new Date().getTime();
+        reply(`https://media.kron.com/nxs-krontv-media-us-east-1/Traffic/cam3_2_large.jpg?cc=${cc}\nhttp://173.164.254.148/vid.cgi?id=S44197_BYLD&doc=East%20Beach%20Webcam&i=1&r=0.6992534210555819`);
+    });
+};
+

--- a/handlers/sf/gg.js
+++ b/handlers/sf/gg.js
@@ -1,32 +1,14 @@
-const fetch = require('@dillonchr/fetch');
-
-const getCrissyFieldCam = (done) => {
-    fetch({
-        url: `http://173.164.254.148/ptz.cgi?doc=East%20Beach%20Webcam&xml=1&cmd=open&version=20100917&kind=ctl`
-    }, (err, body) => {
-        if (err) {
-            done(err);
-        } else {
-            try {
-            const [ignore, id] = body.match(/key="id" value="([^"]+)"/);
-            done(null, `http://173.164.254.148/vid.cgi?id=${id}&doc=East%20Beach%20Webcam&i=1&r=${Math.random()}`);
-            } catch(err) {
-                done(err);
-            }
-        }
-    });
-};
-
+const { exec } = require('child_process');
 
 module.exports = (bot) => {
     bot.hears(['gg','golden gate'], ({reply}) => {
-        const cc = new Date().getTime();
-        reply(`https://media.kron.com/nxs-krontv-media-us-east-1/Traffic/cam3_2_large.jpg?cc=${cc}`);
-        getCrissyFieldCam((err, url) => {
-            if (err) {
-                console.log('CrissyFieldErr:', err);
+        const kron = `https://media.kron.com/nxs-krontv-media-us-east-1/Traffic/cam3_2_large.jpg?cc=${new Date().getTime()}`
+        exec('../../make.sh', {cwd: __dirname, shell: true}, (err, o, stdErr) => {
+            const gifPath = o && !err && o.trim()
+            if (o && o.trim().match(/\.gif$/)) {
+                reply(kron, {files: [o.trim()]});
             } else {
-                reply(url);
+                reply(kron);
             }
         });
     });

--- a/handlers/sf/gg.js
+++ b/handlers/sf/gg.js
@@ -1,7 +1,34 @@
+const fetch = require('@dillonchr/fetch');
+
+const getCrissyFieldCam = (done) => {
+    fetch({
+        url: `http://173.164.254.148/ptz.cgi?doc=East%20Beach%20Webcam&xml=1&cmd=open&version=20100917&kind=ctl`
+    }, (err, body) => {
+        if (err) {
+            done(err);
+        } else {
+            try {
+            const [ignore, id] = body.match(/key="id" value="([^"]+)"/);
+            done(null, `http://173.164.254.148/vid.cgi?id=${id}&doc=East%20Beach%20Webcam&i=1&r=${Math.random()}`);
+            } catch(err) {
+                done(err);
+            }
+        }
+    });
+};
+
+
 module.exports = (bot) => {
     bot.hears(['gg','golden gate'], ({reply}) => {
         const cc = new Date().getTime();
-        reply(`https://media.kron.com/nxs-krontv-media-us-east-1/Traffic/cam3_2_large.jpg?cc=${cc}\nhttp://173.164.254.148/vid.cgi?id=S44197_BYLD&doc=East%20Beach%20Webcam&i=1&r=0.6992534210555819`);
+        reply(`https://media.kron.com/nxs-krontv-media-us-east-1/Traffic/cam3_2_large.jpg?cc=${cc}`);
+        getCrissyFieldCam((err, url) => {
+            if (err) {
+                console.log('CrissyFieldErr:', err);
+            } else {
+                reply(url);
+            }
+        });
     });
 };
 

--- a/handlers/sf/muni.js
+++ b/handlers/sf/muni.js
@@ -1,0 +1,54 @@
+const http = require('http')
+
+const getUrl = (route, stopId) => `http://webservices.nextbus.com/service/publicJSONFeed?command=predictions&a=sf-muni&r=${route}&s=${stopId}`
+
+const getNextStopTimes = (route, stopId, done) => {
+  const req = http.get(getUrl(route, stopId), (res) => {
+    let body = ''
+    res.on('data', chunk => body += chunk)
+    res.on('end', () => done(null, JSON.parse(body)))
+  })
+  req.on('error', err => done(err))
+}
+
+const getSecondsUntilNextBus = (bus, stop, done) => {
+  getNextStopTimes(bus, stop || 6604, (err, res) => {
+    if (err) {
+      return done(err)
+    }
+    try {
+      const { direction } = res.predictions
+      const { prediction } = Array.isArray(direction) ? direction[0] : direction
+      const seconds = +(Array.isArray(prediction) ? prediction[0] : prediction).seconds
+      done(null, seconds)
+    } catch(err) {
+      done(err)
+    }
+  })
+}
+
+const replyWithTime = (reply, bus, err, seconds) => {
+  if (err) {
+    reply(`Something blew up when fetching ${bus}'s predictions: ${err.toString()}`)
+  } else {
+    const min = ~~(seconds/60)
+    const sec = (seconds%60).toString().padStart(2, '0')
+    reply(`**#${bus}** - ${min}:${sec}`)
+  }
+}
+
+module.exports = (bot) => {
+  bot.hears(['muni home'], ({reply}) => {
+    [2,3]
+        .forEach(bus => {
+          getSecondsUntilNextBus(bus, null, replyWithTime.bind(this, reply, bus))
+        })
+  })
+  bot.hears(['muni pg'], ({reply}) => {
+    [30]
+        .forEach(bus => {
+          getSecondsUntilNextBus(bus, 6523, replyWithTime.bind(this, reply, bus))
+        })
+  })
+}
+

--- a/handlers/sf/muni.js
+++ b/handlers/sf/muni.js
@@ -60,8 +60,8 @@ const ROUTES = {
     {route: 30, stop: 6523}
   ],
   mtg: [
-    {route: 2, stop: 6126},
-    {route: 3, stop: 6126},
+    {route: 2, stop: 6594},
+    {route: 3, stop: 6594},
     {route: 47, stop: 6828},
     {route: 49, stop: 6828}
   ],

--- a/handlers/sf/muni.js
+++ b/handlers/sf/muni.js
@@ -68,6 +68,13 @@ const ROUTES = {
   union: [
     {route: 2, stop: 6126},
     {route: 3, stop: 6126}
+  ],
+  crissy: [
+    {route: 2, stop: 6594},
+    {route: 3, stop: 6594},
+    {route: 47, stop: 6830},
+    {route: 49, stop: 6830},
+    {route: 30, stop: 6801}
   ]
 }
 
@@ -75,7 +82,7 @@ module.exports = (bot) => {
   bot.hears(['muni'], ({reply, content}) => {
     const cmd = content.match(/^muni ([a-z]+)/i)
     if (cmd) {
-      const key = cmd[1].toLowerCase()
+      const key = cmd[1]
       if (ROUTES[key]) {
         getSecondsUntilNextBus(ROUTES[key], replyWithErrorHandling.bind(this, reply))
       }

--- a/handlers/sf/muni.js
+++ b/handlers/sf/muni.js
@@ -51,29 +51,35 @@ const replyWithErrorHandling = (reply, err, message) => {
   }
 }
 
+const ROUTES = {
+  home: [
+    {route: 2, stop: 6604},
+    {route: 3, stop: 6604}
+  ],
+  pg: [
+    {route: 30, stop: 6523}
+  ],
+  mtg: [
+    {route: 2, stop: 6126},
+    {route: 3, stop: 6126},
+    {route: 47, stop: 6828},
+    {route: 49, stop: 6828}
+  ],
+  union: [
+    {route: 2, stop: 6126},
+    {route: 3, stop: 6126}
+  ]
+}
+
 module.exports = (bot) => {
-  bot.hears(['muni home'], ({reply}) => {
-    const buses =
-      [
-        {
-          route: 2,
-          stop: 6604
-        },
-        {
-          route: 3,
-          stop: 6604
-        }
-      ]
-    getSecondsUntilNextBus(buses, replyWithErrorHandling.bind(this, reply))
-  })
-  bot.hears(['muni pg'], ({reply}) => {
-    const buses = [
-      {
-        route: 30,
-        stop: 6523
+  bot.hears(['muni'], ({reply, content}) => {
+    const cmd = content.match(/^muni ([a-z]+)/i)
+    if (cmd) {
+      const key = cmd[1].toLowerCase()
+      if (ROUTES[key]) {
+        getSecondsUntilNextBus(ROUTES[key], replyWithErrorHandling.bind(this, reply))
       }
-    ]
-    getSecondsUntilNextBus(buses, replyWithErrorHandling.bind(this, reply))
+    }
   })
 }
 

--- a/handlers/weight.js
+++ b/handlers/weight.js
@@ -107,7 +107,7 @@ module.exports = bot => {
         }
     });
     //  this is necessary because discordbot doesn't check if it's ready
-    setTimeout(() => sendReminders(bot), 10000);
+    //  setTimeout(() => sendReminders(bot), 10000);
 };
 
 

--- a/handlers/xe.js
+++ b/handlers/xe.js
@@ -1,0 +1,26 @@
+const CZK_USD = 0.0434429;
+const EUR_USD = 1.11142;
+const ALL_RATES_RESP = [
+    {rate: CZK_USD, emoji: 'flag_cz'},
+    {rate: EUR_USD, emoji: 'flag_eu'}
+];
+
+const getNumFromContent = (c) => c.match(/[0-9.]+$/);
+
+module.exports = (bot) => {
+    bot.hears(['czk', 'eur', 'euro'], ({content, reply}) => {
+        const num = getNumFromContent(content);
+        const rate = /czk/i.test(content) ? CZK_USD : EUR_USD;
+        if (num) {
+            reply(':flag_us: ' + (num * rate).toFixed(2));
+        }
+    });
+    bot.hears(['usd'], ({content, reply}) => {
+        const num = getNumFromContent(content);
+        if (num) {
+            ALL_RATES_RESP.forEach(({rate, emoji}) => {
+                reply(`:${emoji}: ${(num / rate).toFixed(2)}`);
+            });
+        }
+    });
+};

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const bot = require('@dillonchr/discordbot');
 (require('./handlers/reminders'))(bot);
 (require('./handlers/tempBudget'))(bot);
 (require('./handlers/weight'))(bot);
+(require('./handlers/sf/gg'))(bot);
+(require('./handlers/sf/muni'))(bot);
 
 bot.hears(['uptime'], ({reply}) => {
     let uptime = process.uptime();

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const bot = require('@dillonchr/discordbot');
 (require('./handlers/weight'))(bot);
 (require('./handlers/sf/gg'))(bot);
 (require('./handlers/sf/muni'))(bot);
+(require('./handlers/xe'))(bot);
 
 bot.hears(['uptime'], ({reply}) => {
     let uptime = process.uptime();

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,33 @@
+LOCATION=/tmp/frames
+
+if [ ! -d "$LOCATION" ]; then
+    mkdir -p "$LOCATION"
+fi
+
+ID="$(curl -s http://173.164.254.148/ptz.cgi\?doc\=East%20Beach%20Webcam\&xml\=1\&cmd\=open\&version\=20100917\&kind\=ctl | egrep -o 'key="id" value="([A-Z0-9_]+)"' | sed -n -E 's/.*value="([^"]+)"/\1/p')"
+URL="http://173.164.254.148/vid.cgi?id=${ID}&doc=East%20Beach%20Webcam&i=1"
+
+if [ "$?" -eq "0" ]; then
+    i=0
+    for i in 1 2 3 4 5 6 7 8 9 10
+    do
+        curl -s "${URL}&r=${RANDOM}" > "${LOCATION}/fr-$(date +"%s")-${i}.jpg"
+        i=`expr $i + 1`
+        if [ ! "$?" -eq "0" ]; then
+            echo "Failed to download /shrug"
+            exit 2
+        fi
+    done
+
+    ANIM_PATH="${LOCATION}/anim-$(date +"%s").gif"
+    convert -delay 20 -loop 0 "${LOCATION}/fr-*.jpg" $ANIM_PATH
+
+    if [ "$?" -eq "0" ]; then
+        rm $LOCATION/fr-*.jpg
+        echo $ANIM_PATH
+    else
+        echo "Dang. Sorry dude."
+    fi
+else
+    echo "Sorry dude."
+fi

--- a/make.sh
+++ b/make.sh
@@ -23,11 +23,11 @@ if [ "$?" -eq "0" ]; then
     convert -delay 20 -loop 0 "${LOCATION}/fr-*.jpg" $ANIM_PATH
 
     if [ "$?" -eq "0" ]; then
-        rm $LOCATION/fr-*.jpg
         echo $ANIM_PATH
     else
         echo "Dang. Sorry dude."
     fi
+    rm $LOCATION/fr-*.jpg
 else
     echo "Sorry dude."
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dillonchr/discordbot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@dillonchr/discordbot/-/discordbot-1.0.5.tgz",
-      "integrity": "sha512-XheLVg6ZQSDNNf5oqD0fVOxlpXdJZL26ePdAWylqHIV01iXfJo8HWvoFX1N0NSx5mF1YtxrZSL02xpRahSkWRg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@dillonchr/discordbot/-/discordbot-1.0.7.tgz",
+      "integrity": "sha512-tH/fwOAJkATCFdO4Zhxef0aQGE257Ks9B0XchfC9dg/sm8NQ7frsQCVL28/9HAwicDbX7NOszAPxgpQ4YL3KHw==",
       "requires": {
         "discord.js": "^11.4.2"
       }
@@ -41,9 +41,9 @@
       }
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "charenc": {
       "version": "0.0.2",
@@ -61,22 +61,15 @@
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "discord.js": {
-      "version": "11.4.2",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.4.2.tgz",
-      "integrity": "sha512-MDwpu0lMFTjqomijDl1Ed9miMQe6kB4ifKdP28QZllmLv/HVOJXhatRgjS8urp/wBlOfx+qAYSXcdI5cKGYsfg==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.5.1.tgz",
+      "integrity": "sha512-tGhV5xaZXE3Z+4uXJb3hYM6gQ1NmnSxp9PClcsSAYFVRzH6AJH74040mO3afPDMWEAlj8XsoPXXTJHTxesqcGw==",
       "requires": {
         "long": "^4.0.0",
         "prism-media": "^0.0.3",
         "snekfetch": "^3.6.4",
         "tweetnacl": "^1.0.0",
-        "ws": "^4.0.0"
-      },
-      "dependencies": {
-        "tweetnacl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-        }
+        "ws": "^6.0.0"
       }
     },
     "dotenv": {
@@ -133,11 +126,6 @@
         }
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "snekfetch": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
@@ -153,13 +141,17 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "tweetnacl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+      "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+    },
     "ws": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0"
+        "async-limiter": "~1.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "GPL-2.0",
   "dependencies": {
     "@dillonchr/discordbot": "^1.0.5",
+    "@dillonchr/fetch": "^1.0.1",
     "@dillonchr/funhouse": "^1.1.1",
     "@dillonchr/reminders": "^1.0.0",
     "dotenv": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "dillonchr",
   "license": "GPL-2.0",
   "dependencies": {
-    "@dillonchr/discordbot": "^1.0.5",
+    "@dillonchr/discordbot": "^1.0.7",
     "@dillonchr/fetch": "^1.0.1",
     "@dillonchr/funhouse": "^1.1.1",
     "@dillonchr/reminders": "^1.0.0",


### PR DESCRIPTION
# New commands for when you're in SF

### `gg` - Golden Gate Cams
Kowalski will respond with two URLs that will autofetch thumbs so you can check if the bridge is visible or not. The first image is fixed on the bridge, from KRON 4. The second thumb is a PTZ that can change from time to time but seems to be pointed at GG while I was developing the feature:

<img width="736" alt="_kowalski_-_Discord" src="https://user-images.githubusercontent.com/542890/63909135-7551f300-c9d6-11e9-80d5-34106af882b6.png">

### `muni home` - When's the next 2/3 at Sutter & Powell
Specifically checking the Sutter & Powell (Sutter's a oneway) to hop on and ride it to Hyde to reach the Mithila. So this one will change with each visit I imagine. Def not staying at Mithila again.

### `muni pg` - When's the next 30 at Stockton & Sutter
Not sure if this will change. I mean I really like having visiting the storefront.

## TODO:
- adapt muni to be able to look up routes/directions/stops/predictions and save presets
`muni search sutter` -> `2, 3`
`muni stops 2 out` -> `Mission & Main - 7759, etc.`
`muni save 2 out 6604 home` -> `check {muni home} for next stop at {home}`
